### PR TITLE
Add Prometheus and Grafana monitoring stack

### DIFF
--- a/triton_infer/README.md
+++ b/triton_infer/README.md
@@ -1,0 +1,21 @@
+# Triton Inference with Monitoring
+
+Docker Compose provides services to run the Triton Inference Server together with Prometheus and Grafana for monitoring.
+
+## Run the services
+
+```bash
+docker compose up -d
+```
+
+After the containers start, access the dashboards:
+
+- **Prometheus:** <http://localhost:9090>
+- **Grafana:** <http://localhost:3000> (default credentials `admin`/`admin`)
+
+In Grafana, add a Prometheus data source at `http://prometheus:9090` and import the "Triton Inference Server" dashboard from the [triton-inference-server/server](https://github.com/triton-inference-server/server/tree/main/qa/metrics) repository.
+
+## Additional information
+
+Metrics are enabled with the `--allow-metrics=true` and `--allow-gpu-metrics=true` flags when starting `tritonserver`.
+

--- a/triton_infer/docker-compose.yml
+++ b/triton_infer/docker-compose.yml
@@ -22,8 +22,8 @@ services:
       [
         "tritonserver",
         "--model-repository=/models",
-        # "--allow-metrics=true",
-        # "--allow-gpu-metrics=true",
+        "--allow-metrics=true",
+        "--allow-gpu-metrics=true",
       ]
     volumes:
       - type: bind
@@ -31,6 +31,24 @@ services:
         target: /models
     environment:
       - PYTHONUNBUFFERED=1
+
+  prometheus:
+    image: prom/prometheus:latest
+    restart: always
+    ports:
+      - 9090:9090
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    depends_on:
+      - triton-server
+
+  grafana:
+    image: grafana/grafana:latest
+    restart: always
+    ports:
+      - 3000:3000
+    depends_on:
+      - prometheus
 
   # triton-client:
   #   image: nvcr.io/nvidia/tritonserver:24.07-py3-sdk

--- a/triton_infer/prometheus.yml
+++ b/triton_infer/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'triton-server'
+    static_configs:
+      - targets: ['triton-server:8002']
+


### PR DESCRIPTION
## Summary
- enable Triton metrics flags and expose Prometheus & Grafana services
- add Prometheus scrape configuration
- document how to access monitoring dashboards in English

## Testing
- `docker-compose config` *(fails: No module named 'distutils')*


------
https://chatgpt.com/codex/tasks/task_e_68c6ef898c508326a42e17597c483922