### PR TITLE
Add logging to OCR pipeline and Triton clients

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """FastAPI application exposing the OCR pipeline."""
 
+import logging
 import os
 from typing import List
 
@@ -14,6 +15,31 @@ from src.config import TritonClientConfig
 from src.models.text_detection.factory import TextDetectionFactory
 from src.models.text_recognition.factory import TextRecognitionFactory
 from src.pipeline.ocr import OCRPipeline, OCRPipelineError
+
+
+def _configure_logging() -> None:
+    """Initialise application wide logging.
+
+    Logging configuration is intentionally simple and controlled via the
+    ``LOG_LEVEL`` environment variable (defaults to ``INFO``).  The function is
+    idempotent so importing the module multiple times does not attach duplicate
+    handlers when ``app`` is used by different ASGI servers.
+    """
+
+    if logging.getLogger().handlers:  # pragma: no cover - defensive for ASGI reloads
+        return
+
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+
+_configure_logging()
+logger = logging.getLogger(__name__)
 
 
 class OCRItem(BaseModel):
@@ -44,6 +70,8 @@ def _env_int(name: str) -> int | None:
 
 
 def _build_pipeline() -> OCRPipeline:
+    logger.info("Initialising OCR pipeline using Triton server at '%s'.", os.getenv("TRITON_URL", "localhost:8001"))
+
     client_config = TritonClientConfig(
         url=os.getenv("TRITON_URL", "localhost:8001"),
         protocol=os.getenv("TRITON_PROTOCOL", "http"),
@@ -57,6 +85,8 @@ def _build_pipeline() -> OCRPipeline:
 
     detection_model = TextDetectionFactory.get_instance(client_config, config_path=config_path)
     recognition_model = TextRecognitionFactory.get_instance(client_config, config_path=config_path)
+
+    logger.info("OCR pipeline initialised: detection=%s recognition=%s", detection_model.__class__.__name__, recognition_model.__class__.__name__)
     return OCRPipeline(detection_model, recognition_model)
 
 
@@ -77,6 +107,12 @@ async def infer(file: UploadFile = File(...)) -> OCRResponse:
     if not contents:
         raise HTTPException(status_code=400, detail="Uploaded file is empty.")
 
+    logger.info(
+        "Processing inference request for '%s' (%d bytes).",
+        file.filename or "<unknown>",
+        len(contents),
+    )
+
     image_array = np.frombuffer(contents, dtype=np.uint8)
     image = cv2.imdecode(image_array, cv2.IMREAD_COLOR)
     if image is None:
@@ -85,7 +121,10 @@ async def infer(file: UploadFile = File(...)) -> OCRResponse:
     try:
         results = pipeline.run(image)
     except OCRPipelineError as exc:
+        logger.exception("OCR pipeline failed: %s", exc)
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     except Exception as exc:  # pragma: no cover - safety net for unexpected errors
+        logger.exception("Unexpected OCR failure: %s", exc)
         raise HTTPException(status_code=500, detail="Unexpected OCR failure.") from exc
+    logger.info("Inference completed with %d result(s).", len(results))
     return OCRResponse(results=results)

--- a/src/models/text_detection/model.py
+++ b/src/models/text_detection/model.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 """Text detection model wrapper."""
 
+import logging
+
 import numpy as np
 
 from src.config import TritonClientConfig
@@ -13,6 +15,9 @@ from src.triton.base import BaseTritonClient, TritonClientError
 
 class TextDetectionError(RuntimeError):
     """Raised when the text detection stage fails."""
+
+
+logger = logging.getLogger(__name__)
 
 
 class TextDetectionModel(BaseTritonClient):
@@ -29,6 +34,11 @@ class TextDetectionModel(BaseTritonClient):
 
         if image.ndim != 3 or image.shape[2] != 3:
             raise TextDetectionError("The detection model expects a color image with shape (H, W, 3).")
+
+        logger.debug(
+            "Running detection inference for image with shape %s.",
+            getattr(image, "shape", None),
+        )
 
         try:
             processed_image, shape_list = self._preprocessor(image)
@@ -61,4 +71,5 @@ class TextDetectionModel(BaseTritonClient):
             boxes = self._postprocessor(detection_map.astype(np.float32, copy=False), shape_list)
         except Exception as exc:
             raise TextDetectionError(f"Detection postprocessing failed: {exc}") from exc
+        logger.debug("Detection post-processing returned %d box(es).", len(boxes))
         return boxes

--- a/src/models/text_recognition/model.py
+++ b/src/models/text_recognition/model.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 """Text recognition model wrapper."""
 
+import logging
+
 import numpy as np
 
 from src.config import TritonClientConfig
@@ -13,6 +15,9 @@ from src.triton.base import BaseTritonClient, TritonClientError
 
 class TextRecognitionError(RuntimeError):
     """Raised when the text recognition stage fails."""
+
+
+logger = logging.getLogger(__name__)
 
 
 class TextRecognitionModel(BaseTritonClient):
@@ -29,6 +34,8 @@ class TextRecognitionModel(BaseTritonClient):
 
         if boxes is None or getattr(boxes, "size", 0) == 0:
             return [], np.array([], dtype=np.float32)
+
+        logger.debug("Preparing %d detection box(es) for recognition.", len(boxes) if boxes is not None else 0)
 
         try:
             crops = self._preprocessor(image, boxes)
@@ -63,4 +70,5 @@ class TextRecognitionModel(BaseTritonClient):
             texts, scores = self._postprocessor(logits.astype(np.float32, copy=False))
         except Exception as exc:
             raise TextRecognitionError(f"Recognition postprocessing failed: {exc}") from exc
+        logger.debug("Recognition post-processing generated %d text prediction(s).", len(texts))
         return texts, np.array(scores, dtype=np.float32)

--- a/src/pipeline/ocr.py
+++ b/src/pipeline/ocr.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Composable OCR pipeline built on top of the Triton inference server."""
 
+import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
@@ -27,6 +28,9 @@ class OCRPipelineError(RuntimeError):
     """Raised when a stage of the OCR pipeline fails."""
 
 
+logger = logging.getLogger(__name__)
+
+
 class OCRPipeline:
     """Run text detection followed by recognition and merge their outputs."""
 
@@ -38,15 +42,24 @@ class OCRPipeline:
         return self.run(image)
 
     def run(self, image: np.ndarray) -> List[Dict[str, Any]]:
+        logger.debug("Running detection stage.")
         try:
             boxes = self._detection_model.predict(image)
         except TextDetectionError as exc:
             raise OCRPipelineError(f"Text detection failed: {exc}") from exc
         except Exception as exc:
             raise OCRPipelineError(f"Text detection failed: {exc}") from exc
-        if boxes.size == 0:
-            return []
+        if isinstance(boxes, np.ndarray):
+            num_boxes = 0 if boxes.size == 0 else int(boxes.shape[0])
+            if boxes.size == 0:
+                return []
+        else:
+            num_boxes = len(boxes)
+            if not boxes:
+                return []
+        logger.info("Detection stage produced %d candidate box(es).", num_boxes)
 
+        logger.debug("Running recognition stage for %d box(es).", num_boxes)
         try:
             texts, scores = self._recognition_model.predict(image, boxes)
         except TextRecognitionError as exc:
@@ -54,7 +67,6 @@ class OCRPipeline:
         except Exception as exc:
             raise OCRPipelineError(f"Text recognition failed: {exc}") from exc
         results: List[OCRResult] = []
-        num_boxes = boxes.shape[0]
         for idx in range(num_boxes):
             box = boxes[idx]
             text = texts[idx] if idx < len(texts) else ""
@@ -66,5 +78,5 @@ class OCRPipeline:
                     score=score,
                 )
             )
-
+        logger.info("Recognition stage produced %d OCR result(s).", len(results))
         return [result.as_dict() for result in results]

--- a/src/triton/base.py
+++ b/src/triton/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Base utilities for interacting with the Triton Inference Server."""
 
+import logging
 from typing import Dict, Iterable, Mapping
 
 import numpy as np
@@ -11,6 +12,9 @@ from src.config import ModelIOConfig, ModelOutputConfig, TritonClientConfig, Tri
 
 class TritonClientError(RuntimeError):
     """Raised when the Triton client fails to execute an inference request."""
+
+
+logger = logging.getLogger(__name__)
 
 
 class BaseTritonClient:
@@ -92,14 +96,24 @@ class BaseTritonClient:
         if self.client_config.timeout is not None:
             infer_kwargs["client_timeout"] = self.client_config.timeout
 
+        logger.debug(
+            "Sending Triton inference request for model '%s' with %d input(s) and %d requested output(s).",
+            model_config.model_name,
+            len(infer_inputs),
+            len(requested_outputs) if requested_outputs else 0,
+        )
+
         try:
             response = self.client.infer(**infer_kwargs)
         except Exception as exc:  # pragma: no cover - relies on Triton server interaction
             raise TritonClientError(
                 f"Triton inference failed for model '{model_config.model_name}': {exc}"
             ) from exc
+        logger.debug("Triton inference for model '%s' completed successfully.", model_config.model_name)
         results = {}
         output_names: Iterable[ModelOutputConfig] = model_config.outputs
         for output in output_names:
             results[output.name] = response.as_numpy(output.name)
+        if not output_names:
+            logger.debug("Model '%s' requested all outputs by default.", model_config.model_name)
         return results


### PR DESCRIPTION
## Summary
- configure application logging based on the LOG_LEVEL environment variable
- instrument the FastAPI app, OCR pipeline, and model wrappers with informative log messages
- log Triton inference requests and completions for easier troubleshooting

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68ca8ad48abc83268d404fd9296fe323